### PR TITLE
Use `xcframework` from `feature/add-tvos-support` branch

### DIFF
--- a/SampleAppTest.xcodeproj/project.pbxproj
+++ b/SampleAppTest.xcodeproj/project.pbxproj
@@ -382,8 +382,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/luckygoyal-bitmovin/AdvancedFrameworkPackage.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				branch = "feature/add-tvos-support";
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/SampleAppTest.xcodeproj/project.pbxproj
+++ b/SampleAppTest.xcodeproj/project.pbxproj
@@ -382,8 +382,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/luckygoyal-bitmovin/AdvancedFrameworkPackage.git";
 			requirement = {
-				branch = "feature/add-tvos-support";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/SampleAppTest.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SampleAppTest.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/luckygoyal-bitmovin/AdvancedFrameworkPackage.git",
       "state" : {
-        "branch" : "feature/add-tvos-support",
-        "revision" : "e8e3d88dcab9a0d726409604c70626c05c39fa3a"
+        "revision" : "1041b0e4b6d04a5c291fafcd48c214833029be77",
+        "version" : "1.1.0"
       }
     },
     {

--- a/SampleAppTest.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SampleAppTest.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/luckygoyal-bitmovin/AdvancedFrameworkPackage.git",
       "state" : {
-        "revision" : "abe1faf284dcb00032ad12ba79a657c6b4005ae5",
-        "version" : "1.0.0"
+        "branch" : "feature/add-tvos-support",
+        "revision" : "e8e3d88dcab9a0d726409604c70626c05c39fa3a"
       }
     },
     {


### PR DESCRIPTION
### Description
This PR only changes the dependency to the `xcframework` which was added in https://github.com/luckygoyal-bitmovin/AdvancedFrameworkPackage/pull/1

This now allows building and running the app on simulators. And it would also support a potential tvOS App (which is currently not present)